### PR TITLE
feat: implement Vehicle Module with context-derived driver_id

### DIFF
--- a/cmd/ark-api/main.go
+++ b/cmd/ark-api/main.go
@@ -19,6 +19,7 @@ import (
 	"ark/internal/modules/notification"
 	"ark/internal/modules/order"
 	"ark/internal/modules/pricing"
+	"ark/internal/modules/vehicle"
 )
 
 func main() {
@@ -65,6 +66,9 @@ func main() {
 	calendarStore := calendar.NewStore(dbPool)
 	calendarSvc := calendar.NewService(calendarStore, orderSvc)
 
+	vehicleStore := vehicle.NewStore(dbPool)
+	vehicleSvc := vehicle.NewService(vehicleStore)
+
 	handler := httptransport.NewServer(httptransport.ServerDeps{
 		Order:        orderSvc,
 		Matching:     matchingSvc,
@@ -73,6 +77,7 @@ func main() {
 		AI:           aiSvc,
 		Notification: notificationSvc,
 		Calendar:     calendarSvc,
+		Vehicle:      vehicleSvc,
 	})
 
 	server := &http.Server{Addr: cfg.HTTP.Addr, Handler: handler.Routes()}

--- a/internal/http/handlers/vehicle_handler.go
+++ b/internal/http/handlers/vehicle_handler.go
@@ -1,0 +1,158 @@
+// README: HTTP handlers for the vehicle module.
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"ark/internal/http/middleware"
+	"ark/internal/modules/vehicle"
+	"ark/internal/types"
+)
+
+// VehicleHandler exposes vehicle CRUD endpoints.
+type VehicleHandler struct {
+	svc *vehicle.Service
+}
+
+// NewVehicleHandler creates a VehicleHandler backed by the given service.
+func NewVehicleHandler(svc *vehicle.Service) *VehicleHandler {
+	return &VehicleHandler{svc: svc}
+}
+
+// --- request/response types ---
+
+type createVehicleReq struct {
+	Make             string `json:"make"`
+	Model            string `json:"model"`
+	LicensePlate     string `json:"license_plate"`
+	Capacity         int    `json:"capacity"`
+	VehicleType      string `json:"vehicle_type"`
+	RegistrationDate string `json:"registration_date"` // YYYY-MM-DD
+}
+
+type updateVehicleReq struct {
+	Make         string `json:"make"`
+	Model        string `json:"model"`
+	LicensePlate string `json:"license_plate"`
+	Capacity     int    `json:"capacity"`
+	VehicleType  string `json:"vehicle_type"`
+}
+
+// Create handles POST /api/v1/vehicle.
+// driver_id is taken from auth context; it must NOT be supplied by the client.
+func (h *VehicleHandler) Create(c *gin.Context) {
+	driverID, ok := middleware.DriverIDFromContext(c)
+	if !ok || driverID == "" {
+		writeError(c, http.StatusUnauthorized, "missing driver identity")
+		return
+	}
+	var req createVehicleReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if req.Make == "" || req.Model == "" || req.LicensePlate == "" || req.Capacity <= 0 || req.VehicleType == "" {
+		writeError(c, http.StatusBadRequest, "missing or invalid fields")
+		return
+	}
+	v, err := h.svc.CreateVehicle(c.Request.Context(), types.ID(driverID), vehicle.CreateVehicleCommand{
+		Make:             req.Make,
+		Model:            req.Model,
+		LicensePlate:     req.LicensePlate,
+		Capacity:         req.Capacity,
+		VehicleType:      req.VehicleType,
+		RegistrationDate: req.RegistrationDate,
+	})
+	if err != nil {
+		writeVehicleError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusCreated, vehicleResponse(v))
+}
+
+// GetMe handles GET /api/v1/vehicle/me.
+func (h *VehicleHandler) GetMe(c *gin.Context) {
+	driverID, ok := middleware.DriverIDFromContext(c)
+	if !ok || driverID == "" {
+		writeError(c, http.StatusUnauthorized, "missing driver identity")
+		return
+	}
+	v, err := h.svc.GetDriverVehicle(c.Request.Context(), types.ID(driverID))
+	if err != nil {
+		writeVehicleError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, vehicleResponse(v))
+}
+
+// Update handles PATCH /api/v1/vehicle.
+func (h *VehicleHandler) Update(c *gin.Context) {
+	driverID, ok := middleware.DriverIDFromContext(c)
+	if !ok || driverID == "" {
+		writeError(c, http.StatusUnauthorized, "missing driver identity")
+		return
+	}
+	var req updateVehicleReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if req.Make == "" || req.Model == "" || req.LicensePlate == "" || req.Capacity <= 0 || req.VehicleType == "" {
+		writeError(c, http.StatusBadRequest, "missing or invalid fields")
+		return
+	}
+	v, err := h.svc.UpdateVehicleInfo(c.Request.Context(), types.ID(driverID), vehicle.UpdateVehicleCommand{
+		Make:         req.Make,
+		Model:        req.Model,
+		LicensePlate: req.LicensePlate,
+		Capacity:     req.Capacity,
+		VehicleType:  req.VehicleType,
+	})
+	if err != nil {
+		writeVehicleError(c, err)
+		return
+	}
+	writeJSON(c, http.StatusOK, vehicleResponse(v))
+}
+
+// Delete handles DELETE /api/v1/vehicle.
+func (h *VehicleHandler) Delete(c *gin.Context) {
+	driverID, ok := middleware.DriverIDFromContext(c)
+	if !ok || driverID == "" {
+		writeError(c, http.StatusUnauthorized, "missing driver identity")
+		return
+	}
+	if err := h.svc.DeleteVehicle(c.Request.Context(), types.ID(driverID)); err != nil {
+		writeVehicleError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func vehicleResponse(v *vehicle.Vehicle) map[string]any {
+	return map[string]any{
+		"vehicle_id":        v.ID,
+		"driver_id":         v.DriverID,
+		"make":              v.Make,
+		"model":             v.Model,
+		"license_plate":     v.LicensePlate,
+		"capacity":          v.Capacity,
+		"vehicle_type":      v.Type,
+		"registration_date": v.RegistrationDate,
+	}
+}
+
+func writeVehicleError(c *gin.Context, err error) {
+	switch err {
+	case vehicle.ErrBadRequest:
+		writeError(c, http.StatusBadRequest, err.Error())
+	case vehicle.ErrNotFound:
+		writeError(c, http.StatusNotFound, err.Error())
+	case vehicle.ErrConflict:
+		writeError(c, http.StatusConflict, err.Error())
+	default:
+		writeError(c, http.StatusInternalServerError, "internal error")
+	}
+}

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -3,10 +3,29 @@ package middleware
 
 import "github.com/gin-gonic/gin"
 
-// [TODO] Implement real auth with JWT or similar in the future. For MVP, this is a no-op.
+// [TODO] Implement real auth with JWT or similar in the future.
+// For MVP, driver_id is read from the X-Driver-ID request header and stored in Gin context.
 
+const ContextKeyDriverID = "driver_id"
+
+// Auth sets auth-derived claims in the Gin context.
+// MVP stub: reads driver_id from the X-Driver-ID header.
 func Auth() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if driverID := c.GetHeader("X-Driver-ID"); driverID != "" {
+			c.Set(ContextKeyDriverID, driverID)
+		}
 		c.Next()
 	}
+}
+
+// DriverIDFromContext extracts the driver_id stored in the Gin context by the Auth middleware.
+// Returns ("", false) when no driver identity is present.
+func DriverIDFromContext(c *gin.Context) (string, bool) {
+	v, ok := c.Get(ContextKeyDriverID)
+	if !ok {
+		return "", false
+	}
+	id, ok := v.(string)
+	return id, ok
 }

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -15,6 +15,7 @@ import (
 	"ark/internal/modules/notification"
 	"ark/internal/modules/order"
 	"ark/internal/modules/pricing"
+	"ark/internal/modules/vehicle"
 )
 
 // [TODO] We might want to check if the user have the permission to access the order
@@ -27,6 +28,7 @@ func NewRouter(
 	aiService *aiusage.Service,
 	notificationService *notification.Service,
 	calendarService *calendar.Service,
+	vehicleService *vehicle.Service,
 ) *gin.Engine {
 	// r := gin.New()
 	// r.Use(middleware.Recovery())
@@ -82,6 +84,13 @@ func NewRouter(
 	r.POST("/api/calendar/schedules", calendarHandler.CreateAndTieOrder)
 	r.DELETE("/api/calendar/schedules/:event_id/order", calendarHandler.UntieOrder)
 	r.GET("/api/calendar/schedules", calendarHandler.ListSchedules)
+
+	// vehicle — driver registers/manages their vehicle; driver_id injected from auth context
+	vehicleHandler := handlers.NewVehicleHandler(vehicleService)
+	r.POST("/api/v1/vehicle", vehicleHandler.Create)
+	r.GET("/api/v1/vehicle/me", vehicleHandler.GetMe)
+	r.PATCH("/api/v1/vehicle", vehicleHandler.Update)
+	r.DELETE("/api/v1/vehicle", vehicleHandler.Delete)
 
 	return r
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -11,6 +11,7 @@ import (
 	"ark/internal/modules/notification"
 	"ark/internal/modules/order"
 	"ark/internal/modules/pricing"
+	"ark/internal/modules/vehicle"
 )
 
 type ServerDeps struct {
@@ -21,6 +22,7 @@ type ServerDeps struct {
 	AI           *aiusage.Service
 	Notification *notification.Service
 	Calendar     *calendar.Service
+	Vehicle      *vehicle.Service
 }
 
 type Server struct {
@@ -28,7 +30,7 @@ type Server struct {
 }
 
 func NewServer(deps ServerDeps) *Server {
-	engine := NewRouter(deps.Order, deps.Matching, deps.Location, deps.Pricing, deps.AI, deps.Notification, deps.Calendar)
+	engine := NewRouter(deps.Order, deps.Matching, deps.Location, deps.Pricing, deps.AI, deps.Notification, deps.Calendar, deps.Vehicle)
 	return &Server{Engine: engine}
 }
 

--- a/internal/modules/vehicle/model.go
+++ b/internal/modules/vehicle/model.go
@@ -1,0 +1,25 @@
+// README: Vehicle domain model.
+package vehicle
+
+import "ark/internal/types"
+
+// VehicleType enumerates the supported vehicle categories.
+type VehicleType string
+
+const (
+	VehicleTypeSedan VehicleType = "sedan"
+	VehicleTypeSUV   VehicleType = "suv"
+	VehicleTypeBike  VehicleType = "bike"
+)
+
+// Vehicle represents a driver's registered vehicle.
+type Vehicle struct {
+	ID               types.ID
+	DriverID         types.ID
+	Make             string
+	Model            string
+	LicensePlate     string
+	Capacity         int
+	Type             VehicleType
+	RegistrationDate string // YYYY-MM-DD
+}

--- a/internal/modules/vehicle/service.go
+++ b/internal/modules/vehicle/service.go
@@ -1,0 +1,125 @@
+// README: Vehicle service — registers, retrieves, updates, and removes driver vehicles.
+package vehicle
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+
+	"ark/internal/types"
+)
+
+var (
+	ErrNotFound   = errors.New("vehicle: not found")
+	ErrBadRequest = errors.New("vehicle: bad request")
+	ErrConflict   = errors.New("vehicle: driver already has a vehicle")
+)
+
+// Service orchestrates vehicle business logic.
+type Service struct {
+	store *Store
+}
+
+// NewService creates a Service backed by the given Store.
+func NewService(store *Store) *Service {
+	return &Service{store: store}
+}
+
+// CreateVehicleCommand holds the fields supplied by the driver when registering a vehicle.
+// driver_id is NOT part of the command; it is injected from auth context by the handler.
+type CreateVehicleCommand struct {
+	Make             string
+	Model            string
+	LicensePlate     string
+	Capacity         int
+	VehicleType      string
+	RegistrationDate string // YYYY-MM-DD
+}
+
+// UpdateVehicleCommand holds the mutable fields a driver may change.
+// registration_date is excluded per spec.
+type UpdateVehicleCommand struct {
+	Make         string
+	Model        string
+	LicensePlate string
+	Capacity     int
+	VehicleType  string
+}
+
+// CreateVehicle registers a new vehicle for the authenticated driver.
+func (s *Service) CreateVehicle(ctx context.Context, driverID types.ID, cmd CreateVehicleCommand) (*Vehicle, error) {
+	if driverID == "" || cmd.Make == "" || cmd.Model == "" || cmd.LicensePlate == "" || cmd.Capacity <= 0 {
+		return nil, ErrBadRequest
+	}
+	if !isValidVehicleType(cmd.VehicleType) {
+		return nil, ErrBadRequest
+	}
+	v := &Vehicle{
+		ID:               newID(),
+		DriverID:         driverID,
+		Make:             cmd.Make,
+		Model:            cmd.Model,
+		LicensePlate:     cmd.LicensePlate,
+		Capacity:         cmd.Capacity,
+		Type:             VehicleType(cmd.VehicleType),
+		RegistrationDate: cmd.RegistrationDate,
+	}
+	if err := s.store.Create(ctx, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// GetDriverVehicle returns the vehicle currently bound to the given driver.
+// Also used by order and matching modules.
+func (s *Service) GetDriverVehicle(ctx context.Context, driverID types.ID) (*Vehicle, error) {
+	if driverID == "" {
+		return nil, ErrBadRequest
+	}
+	return s.store.GetByDriverID(ctx, driverID)
+}
+
+// UpdateVehicleInfo updates the mutable fields of the driver's vehicle.
+func (s *Service) UpdateVehicleInfo(ctx context.Context, driverID types.ID, cmd UpdateVehicleCommand) (*Vehicle, error) {
+	if driverID == "" || cmd.Make == "" || cmd.Model == "" || cmd.LicensePlate == "" || cmd.Capacity <= 0 {
+		return nil, ErrBadRequest
+	}
+	if !isValidVehicleType(cmd.VehicleType) {
+		return nil, ErrBadRequest
+	}
+	v := &Vehicle{
+		DriverID:     driverID,
+		Make:         cmd.Make,
+		Model:        cmd.Model,
+		LicensePlate: cmd.LicensePlate,
+		Capacity:     cmd.Capacity,
+		Type:         VehicleType(cmd.VehicleType),
+	}
+	if err := s.store.Update(ctx, v); err != nil {
+		return nil, err
+	}
+	return s.store.GetByDriverID(ctx, driverID)
+}
+
+// DeleteVehicle removes the vehicle record for the given driver.
+func (s *Service) DeleteVehicle(ctx context.Context, driverID types.ID) error {
+	if driverID == "" {
+		return ErrBadRequest
+	}
+	return s.store.DeleteByDriverID(ctx, driverID)
+}
+
+func isValidVehicleType(t string) bool {
+	switch VehicleType(t) {
+	case VehicleTypeSedan, VehicleTypeSUV, VehicleTypeBike:
+		return true
+	}
+	return false
+}
+
+func newID() types.ID {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return types.ID(hex.EncodeToString(b[:]))
+}

--- a/internal/modules/vehicle/store.go
+++ b/internal/modules/vehicle/store.go
@@ -1,0 +1,82 @@
+// README: Vehicle store backed by PostgreSQL.
+package vehicle
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"ark/internal/types"
+)
+
+// Store handles persistence for vehicles.
+type Store struct {
+	db *pgxpool.Pool
+}
+
+// NewStore creates a Store backed by the given connection pool.
+func NewStore(db *pgxpool.Pool) *Store {
+	return &Store{db: db}
+}
+
+// Create inserts a new vehicle record.
+func (s *Store) Create(ctx context.Context, v *Vehicle) error {
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO vehicles (id, driver_id, make, model, license_plate, capacity, vehicle_type, registration_date)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		string(v.ID), string(v.DriverID), v.Make, v.Model, v.LicensePlate,
+		v.Capacity, string(v.Type), v.RegistrationDate,
+	)
+	return err
+}
+
+// GetByDriverID retrieves the vehicle bound to the given driver.
+func (s *Store) GetByDriverID(ctx context.Context, driverID types.ID) (*Vehicle, error) {
+	row := s.db.QueryRow(ctx, `
+		SELECT id, driver_id, make, model, license_plate, capacity, vehicle_type, registration_date
+		FROM vehicles
+		WHERE driver_id = $1`,
+		string(driverID),
+	)
+	var v Vehicle
+	err := row.Scan(&v.ID, &v.DriverID, &v.Make, &v.Model, &v.LicensePlate,
+		&v.Capacity, &v.Type, &v.RegistrationDate)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// Update modifies the mutable fields of a driver's vehicle (excludes registration_date).
+func (s *Store) Update(ctx context.Context, v *Vehicle) error {
+	tag, err := s.db.Exec(ctx, `
+		UPDATE vehicles
+		SET make = $1, model = $2, license_plate = $3, capacity = $4, vehicle_type = $5
+		WHERE driver_id = $6`,
+		v.Make, v.Model, v.LicensePlate, v.Capacity, string(v.Type), string(v.DriverID),
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeleteByDriverID removes the vehicle record associated with the given driver.
+func (s *Store) DeleteByDriverID(ctx context.Context, driverID types.ID) error {
+	tag, err := s.db.Exec(ctx, `DELETE FROM vehicles WHERE driver_id = $1`, string(driverID))
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/migrations/0006_vehicle.sql
+++ b/migrations/0006_vehicle.sql
@@ -1,0 +1,15 @@
+-- README: Creates the vehicles table for the vehicle module.
+
+CREATE TABLE IF NOT EXISTS vehicles (
+    id                TEXT PRIMARY KEY,
+    driver_id         TEXT NOT NULL UNIQUE,
+    make              TEXT NOT NULL,
+    model             TEXT NOT NULL,
+    license_plate     TEXT NOT NULL,
+    capacity          INT  NOT NULL CHECK (capacity > 0),
+    vehicle_type      TEXT NOT NULL CHECK (vehicle_type IN ('sedan', 'suv', 'bike')),
+    registration_date TEXT,
+    created_at        TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicles_driver_id ON vehicles (driver_id);


### PR DESCRIPTION
- Add internal/modules/vehicle with model, store, and service
- driver_id is injected from auth context (not from client input)
- CRUD routes: POST/GET/PATCH/DELETE /api/v1/vehicle
- Update auth middleware to extract driver_id from X-Driver-ID header (MVP stub)
- Add DriverIDFromContext helper in middleware package
- Wire vehicle module into server deps, router, and main
- Add migrations/0006_vehicle.sql with vehicles table

Resolves #48